### PR TITLE
New feature: converting to byte array (big endian)

### DIFF
--- a/Example/main.m
+++ b/Example/main.m
@@ -28,6 +28,16 @@ int main(int argc, const char *argv[]) {
         JKBigInteger *int6 = [[JKBigInteger alloc] initWithString:@"123"];
 
         NSLog(@"%@ / %@ = %@", int5, int6, [int5 divide:int6]);
+        
+        unsigned int numBytesInt5 = [int5 countBytes];
+        unsigned char bytes[numBytesInt5];
+        
+        [int5 toByteArrayUnsigned:bytes];
+        
+        for(unsigned i = 0; i < numBytesInt5; i++)
+        {
+            NSLog(@"Byte %d: %X", i, bytes[i]);
+        }
     }
     return 0;
 }

--- a/JKBigInteger/JKBigInteger.h
+++ b/JKBigInteger/JKBigInteger.h
@@ -49,4 +49,8 @@
 
 - (NSString *)description;
 
+- (unsigned int)countBytes;
+- (void)toByteArraySigned: (unsigned char*) byteArray;
+- (void)toByteArrayUnsigned: (unsigned char*) byteArray;
+
 @end

--- a/JKBigInteger/JKBigInteger.m
+++ b/JKBigInteger/JKBigInteger.m
@@ -376,4 +376,19 @@
     mp_clear(&m_value);
 }
 
+/* Returns the number of bytes required to store this JKBigInteger as binary */
+- (unsigned int)countBytes {
+    return (unsigned int) mp_unsigned_bin_size(&m_value);
+}
+
+/* Retrieves the signed [big endian] format of this JKBigInteger */
+- (void)toByteArraySigned: (unsigned char*) byteArray {
+    mp_to_signed_bin(&m_value, byteArray);
+}
+
+/* Retrieves the unsigned [big endian] format of this JKBigInteger */
+- (void)toByteArrayUnsigned: (unsigned char*) byteArray {
+    mp_to_unsigned_bin(&m_value, byteArray);
+}
+
 @end

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ JKBigInteger *int5 = [[JKBigInteger alloc] initWithString:@"10000001234567890123
 JKBigInteger *int6 = [[JKBigInteger alloc] initWithString:@"123"];
 
 NSLog(@"%@ / %@ = %@", int5, int6, [int5 divide:int6]);
+
+unsigned int numBytesInt5 = [int5 countBytes];
+unsigned char bytes[numBytesInt5];
+        
+[int5 toByteArrayUnsigned:bytes];
+        
+for(unsigned i = 0; i < numBytesInt5; i++)
+{
+     NSLog(@"Byte %d: %X", i, bytes[i]);
+}
 ```
 
 ## Credits


### PR DESCRIPTION
Added some methods to convert the bigint into a byte array in Big Endian format (coders from Java background can find this very handy when porting code to iOS).
