### PR TITLE
Support NSSecureCoding

### DIFF
--- a/JKBigInteger iOSTests/JKBigInteger_iOSTests.m
+++ b/JKBigInteger iOSTests/JKBigInteger_iOSTests.m
@@ -11,6 +11,9 @@
 
 @interface JKBigInteger_iOSTests : XCTestCase
 
+- (void)testSecureArchivingPositiveInt API_AVAILABLE(ios(11), macos(10.13));
+- (void)testSecureArchivingNegativeInt API_AVAILABLE(ios(11), macos(10.13));
+
 @end
 
 @implementation JKBigInteger_iOSTests
@@ -53,6 +56,40 @@
 
     int2 = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
     XCTAssertEqualObjects([int1 stringValue], [int2 stringValue], @"Test archiving failed!");
+}
+
+- (void)testSecureArchivingPositiveInt {
+    NSError *int1Error;
+    JKBigInteger *int1 = [[JKBigInteger alloc] initWithString:@"1111222233334444555566667777888899990000"];
+    NSData *intData = [NSKeyedArchiver archivedDataWithRootObject:int1
+                                            requiringSecureCoding:YES
+                                                            error:&int1Error];
+    XCTAssertNil(int1Error, "archivedDataWithRootObject failed");
+
+    NSError *int2Error;
+    JKBigInteger *int2 = [NSKeyedUnarchiver unarchivedObjectOfClass:[JKBigInteger class]
+                                                           fromData:intData
+                                                              error:&int2Error];
+    XCTAssertNil(int2Error, "unarchivedObjectOfClass failed");
+
+    XCTAssertEqualObjects([int1 stringValue], [int2 stringValue], @"Test secure archiving failed!");
+}
+
+- (void)testSecureArchivingNegativeInt {
+    NSError *int1Error;
+    JKBigInteger *int1 = [[JKBigInteger alloc] initWithString:@"-123471238940713294701327508917230516230561320512352315021305012395091032950923520395013258623185465463545681428354162345612435416523"];
+    NSData *intData = [NSKeyedArchiver archivedDataWithRootObject:int1
+                                            requiringSecureCoding:YES
+                                                            error:&int1Error];
+    XCTAssertNil(int1Error, "archivedDataWithRootObject failed");
+
+    NSError *int2Error;
+    JKBigInteger *int2 = [NSKeyedUnarchiver unarchivedObjectOfClass:[JKBigInteger class]
+                                                           fromData:intData
+                                                              error:&int2Error];
+    XCTAssertNil(int2Error, "unarchivedObjectOfClass failed");
+
+    XCTAssertEqualObjects([int1 stringValue], [int2 stringValue], @"Test secure archiving failed!");
 }
 
 - (void)testDescription0 {

--- a/JKBigInteger/JKBigDecimal.h
+++ b/JKBigInteger/JKBigDecimal.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import "JKBigInteger.h"
 
-@interface JKBigDecimal : NSObject <NSCoding>
+@interface JKBigDecimal : NSObject <NSSecureCoding>
 
 @property(nonatomic, retain)JKBigInteger *bigInteger;
 @property(nonatomic, assign)NSUInteger figure;//小数位数

--- a/JKBigInteger/JKBigDecimal.m
+++ b/JKBigInteger/JKBigDecimal.m
@@ -11,6 +11,11 @@
 @implementation JKBigDecimal
 @synthesize bigInteger, figure;
 
++ (BOOL)supportsSecureCoding
+{
+	return YES;
+}
+
 - (id)init
 {
     return [self initWithString:@"0"];

--- a/JKBigInteger/JKBigInteger.h
+++ b/JKBigInteger/JKBigInteger.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #include "tommath.h"
 
-@interface JKBigInteger : NSObject <NSCoding>
+@interface JKBigInteger : NSObject <NSSecureCoding>
 
 - (id)initWithValue:(mp_int *)value;
 - (mp_int *)value;

--- a/JKBigInteger/JKBigInteger.m
+++ b/JKBigInteger/JKBigInteger.m
@@ -12,6 +12,10 @@
     mp_int m_value;
 }
 
++ (BOOL)supportsSecureCoding {
+	return YES;
+}
+
 - (id)initWithValue:(mp_int *)value {
 
     self = [super init];
@@ -89,7 +93,7 @@
 
 		mp_init_size(&m_value, alloc);
 		
-		NSData *data = (NSData *)[decoder decodeObjectForKey:@"JKBigIntegerDP"];
+		NSData *data = (NSData *)[decoder decodeObjectOfClass:[NSData class] forKey:@"JKBigIntegerDP"];
         mp_digit *temp = (mp_digit *)[data bytes];
         
         for (unsigned int i = 0; i < alloc; ++i) {

--- a/Unit Tests/Unit_Tests.h
+++ b/Unit Tests/Unit_Tests.h
@@ -10,4 +10,7 @@
 
 @interface Unit_Tests : XCTestCase
 
+- (void)testSecureArchivingPositiveInt API_AVAILABLE(ios(11), macos(10.13));
+- (void)testSecureArchivingNegativeInt API_AVAILABLE(ios(11), macos(10.13));
+
 @end

--- a/Unit Tests/Unit_Tests.m
+++ b/Unit Tests/Unit_Tests.m
@@ -51,6 +51,40 @@
     XCTAssertEqualObjects([int1 stringValue], [int2 stringValue], @"Test archiving failed!");
 }
 
+- (void)testSecureArchivingPositiveInt {
+    NSError *int1Error;
+    JKBigInteger *int1 = [[JKBigInteger alloc] initWithString:@"1111222233334444555566667777888899990000"];
+    NSData *intData = [NSKeyedArchiver archivedDataWithRootObject:int1
+                                            requiringSecureCoding:YES
+                                                            error:&int1Error];
+    XCTAssertNil(int1Error, "archivedDataWithRootObject failed");
+
+    NSError *int2Error;
+    JKBigInteger *int2 = [NSKeyedUnarchiver unarchivedObjectOfClass:[JKBigInteger class]
+                                                           fromData:intData
+                                                              error:&int2Error];
+    XCTAssertNil(int2Error, "unarchivedObjectOfClass failed");
+
+    XCTAssertEqualObjects([int1 stringValue], [int2 stringValue], @"Test secure archiving failed!");
+}
+
+- (void)testSecureArchivingNegativeInt {
+    NSError *int1Error;
+    JKBigInteger *int1 = [[JKBigInteger alloc] initWithString:@"-123471238940713294701327508917230516230561320512352315021305012395091032950923520395013258623185465463545681428354162345612435416523"];
+    NSData *intData = [NSKeyedArchiver archivedDataWithRootObject:int1
+                                            requiringSecureCoding:YES
+                                                            error:&int1Error];
+    XCTAssertNil(int1Error, "archivedDataWithRootObject failed");
+
+    NSError *int2Error;
+    JKBigInteger *int2 = [NSKeyedUnarchiver unarchivedObjectOfClass:[JKBigInteger class]
+                                                           fromData:intData
+                                                              error:&int2Error];
+    XCTAssertNil(int2Error, "unarchivedObjectOfClass failed");
+
+    XCTAssertEqualObjects([int1 stringValue], [int2 stringValue], @"Test secure archiving failed!");
+}
+
 - (void)testDescription0 {
     JKBigInteger *int1 = [[JKBigInteger alloc] initWithString:@"2131231231231231231231231231231231231239876543210"];
     NSString *result = [NSString stringWithFormat:@"%@", int1];


### PR DESCRIPTION
Support NSSecureCoding, an API Apple introduced in 2012 to increase the
overall security posture of apps by making them resilient against object
substitution attacks. This change adds conformance to the `NSSecureCoding`
protocol, adds required method implementations for `+[supportsSecureCoding]`,
and adds unit tests to ensure secure archiving works with methods Apple
provided in later versions of the operating systems.

Please note that in order to get tests to run I had to make some changes to the project file that are not included in this change, since I don't understand the reasoning behind the current project structure. However, after changing the targets to which the `.m` and `.c` files belong, I was able to run both the Mac and iOS unit test suites, including the new tests, successfully.